### PR TITLE
Added prioritizing sticky posts and user attibution to homepage  Added sticky to createPosts

### DIFF
--- a/application/home.py
+++ b/application/home.py
@@ -6,7 +6,7 @@ from mongoengine import ValidationError, errors
 @app.route('/')
 def index():
 	posts = []
-	posts = Posts.objects.order_by('-score', '-created_at')
+	posts = Posts.objects.order_by('-sticky', '-score', '-created_at')
 
 	return render_template('index.html', posts = posts) # variables go after template
 

--- a/application/static/css/style.css
+++ b/application/static/css/style.css
@@ -56,6 +56,11 @@ body{
     text-decoration: none;
 }
 
+.by{
+    font-size: 15;
+}
+
+
 .container {
     margin-top:50px;
 }

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -7,7 +7,7 @@
 	-->
 	{% if len(posts) > 0 %}
 		{% for post in posts %}
-			<div class="row"><a class="npf" href="{{ url_for('post', uid=post.id) }}">{{ post.title }}</a></div>
+			<div class="row npf"><div class="col-md-10"><a href="{{ url_for('post', uid=post.id) }}">{{ post.title }}</a></div><div class="col-md-2 by">By <a href="{{ url_for('profile',  name=post.author.alias) }}">{{ post.author.alias }}</a></div></div>
 		{% endfor %}
 	{% else %}
 		<h2 class="npf"> No Posts Found :( </h2>

--- a/tools/createPost.py
+++ b/tools/createPost.py
@@ -33,6 +33,7 @@ class Posts(Document):
     #max length of content is 10000 characters
     content = StringField(max_length = 10000)
     score = IntField(default = 0)
+    sticky = BooleanField(default = False)
     comments = ListField(EmbeddedDocumentField('Comment'))
     meta = {
         'allow_inheritance': True
@@ -41,12 +42,11 @@ class Posts(Document):
 
 alias = raw_input('alias: ')
 
-#uncomment when sticky posts added
-'''stick = raw_input('sticky [Y/n]: ')
+stick = raw_input('sticky [Y/n]: ')
 if stick.lower() in ['y', 'yes']:
     stick = True
 else:
-    stick = False'''
+    stick = False
 
 score = raw_input('score: ')
 
@@ -56,7 +56,7 @@ content = raw_input('post (Not required.  Must be under 1000 characters): ')
 
 try:
     user = User.objects(alias=alias)[0]  # returns user object by alias
-    post = Posts(author=user, title=title, content=content, score=score)
+    post = Posts(author=user, title=title, content=content, score=score, sticky=stick)
 
     post.save()
 


### PR DESCRIPTION
CreatePost.py can now create sticky posts.  
Sticky posts are now listed first on home page.  
Posts are now attributed to users on home page.  (Do we want this?)
![screenshot from 2015-05-02 09 24 18](https://cloud.githubusercontent.com/assets/11617907/7441815/1057f564-f0ad-11e4-963f-74b6d3ca38bd.png)
